### PR TITLE
Fixes

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,10 @@ importNewTemplateFolder = async function (handle) {
 
   const relativePath = `./${handle}`
   fsUtils.createFolders(relativePath)
-  testFile = { name: "test", content: reconciliationText.tests }
+  testFile = { 
+    name: "test", 
+    content: reconciliationText.tests | ""
+  }
   textPartsReducer = (acc, part) => {
     acc[part.name] = part.content
     return acc

--- a/sf_api.js
+++ b/sf_api.js
@@ -35,11 +35,11 @@ const updateReconciliationText = function(id, attributes) {
 }
 
 const createTestRun = function(attributes) {
-  return axios.post('reconciliations/test', attributes, axiosConfig())
+  return axios.post('reconciliations/test', attributes)
 }
 
 const fetchTestRun = function(id) {
-  return axios.get(`reconciliations/test_runs/${id}`, axiosConfig())
+  return axios.get(`reconciliations/test_runs/${id}`)
  }
 
 module.exports = { fetchReconciliationTexts, updateReconciliationText, findReconciliationText, fetchTestRun, createTestRun }


### PR DESCRIPTION
- `axiosConfig()` was still used as a parameter for `runTests`.
- We try to fetch the liquid tests from the API, but that information is not provided (yet?). We need to create an empty file if it doesn't exist.

Both issues were raising blocking errors.

Now, I can run `run_tests --handle <handle>` without blocking errors, but I always received `undefined` as a response in the terminal. This is the response we get from the API: `{ status: 'internal_error' }`